### PR TITLE
feat: change the init() to be an explicit action triggered from consumer code

### DIFF
--- a/src/js/cerner-smart-embeddable-lib.js
+++ b/src/js/cerner-smart-embeddable-lib.js
@@ -2,6 +2,12 @@
 
 import { Provider } from 'xfc';
 
+const predefinedACLs = [
+  'https://embedded.cerner.com',
+  'https://embedded.sandboxcerner.com',
+  'https://embedded.devcerner.com',
+];
+
 /**
 * Wrapper object to initialize the provider's content
 * to allow content to embed inside an iframe.
@@ -11,12 +17,10 @@ const CernerSmartEmbeddableLib = {
   /**
   * Initializes the provider wrapper object with ACLs.
   */
-  init: () => {
-    Provider.init({
-      acls: ['https://embedded.cerner.com',
-        'https://embedded.sandboxcerner.com', 'https://embedded.devcerner.com'],
-    });
+  init: (acls = predefinedACLs) => {
+    Provider.init({ acls });
   },
+
   /**
   * Get the frame height.  The default height is HTML's scrollHeight.
   */
@@ -29,6 +33,7 @@ const CernerSmartEmbeddableLib = {
   setFrameHeight: (h) => {
     Provider.trigger('iframeCustomResizer', { height: h });
   },
+
   /**
   * Listen for iframeCustomResizer message.
   * Calculate the frame height in px and set the height.

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -2,9 +2,11 @@
 
 import CernerSmartEmbeddableLib from './cerner-smart-embeddable-lib';
 
-CernerSmartEmbeddableLib.init();
-CernerSmartEmbeddableLib.listenForCustomFrameHeight();
+export const initializeCernerSmartEmbeddableLib = (acls) => {
+  CernerSmartEmbeddableLib.init(acls);
+  CernerSmartEmbeddableLib.listenForCustomFrameHeight();
 
-window.CernerSmartEmbeddableLib = window.CernerSmartEmbeddableLib || {};
-window.CernerSmartEmbeddableLib.calcFrameHeight = CernerSmartEmbeddableLib.calcFrameHeight;
-window.CernerSmartEmbeddableLib.setFrameHeight = CernerSmartEmbeddableLib.setFrameHeight;
+  window.CernerSmartEmbeddableLib = window.CernerSmartEmbeddableLib || {};
+  window.CernerSmartEmbeddableLib.calcFrameHeight = CernerSmartEmbeddableLib.calcFrameHeight;
+  window.CernerSmartEmbeddableLib.setFrameHeight = CernerSmartEmbeddableLib.setFrameHeight;
+};


### PR DESCRIPTION
There is currently a problem with the way the library is consumed from the client code.

The import of the library with `import 'cerner-smart-embeddable-lib'` results in an unconditional execution of the `CernerSmartEmbeddableLib.init();` line, which is not always desirable.
In a the context of our React application and its build setup it is difficult to achieve a conditional import of this library.
The proposal is to expose a single function (e.g. `initializeCernerSmartEmbeddableLib()`) that can be invoked from the consumer code as necessary.
Introduction of such change requires the major version bump as it's not backwards compatible.

Another problem is that the list of ACLs is hard coded and limited to `'https://embedded.cerner.com', 'https://embedded.sandboxcerner.com', 'https://embedded.devcerner.com'`. This may not be sufficient in many cases.
The proposal is to make the `init()` function receive `acls` as a parameter (maybe with a pre-defined old value).

Looking forward to feedback.

Thank you!